### PR TITLE
Timeout fix

### DIFF
--- a/dist/Tinlake.d.ts
+++ b/dist/Tinlake.d.ts
@@ -106,6 +106,7 @@ declare class Tinlake {
      */
     adminAdmit: (registry: string, nft: string, principal: string, owner: string) => Promise<Events>;
     adminAppraise: (loanID: string, appraisal: string) => Promise<Events>;
+    getAppraisal: (loanID: string) => Promise<BN>;
     /**
      * @param to Address that should receive the currency (e. g. DAI)
      */

--- a/dist/Tinlake.es.js
+++ b/dist/Tinlake.es.js
@@ -24130,7 +24130,7 @@ var waitAndReturnEvents = function (eth, txHash, abi) {
 // todo replace with a better polling
 var waitForTransaction = function (eth, txHash) {
     return new Promise(function (resolve, reject) {
-        var secMax = 5;
+        var secMax = 30;
         var sec = 0;
         var wait = function (txHash) {
             setTimeout(function () {
@@ -24145,8 +24145,11 @@ var waitForTransaction = function (eth, txHash) {
                     }
                     console.log("waiting for tx :" + txHash);
                     sec = sec + 1;
-                    if (sec !== secMax) {
+                    if (sec < secMax) {
                         wait(txHash);
+                    }
+                    else {
+                        reject("waiting for transaction tx " + tx + " timed out after " + secMax + " seconds");
                     }
                 });
             }, 1000);

--- a/dist/Tinlake.es.js
+++ b/dist/Tinlake.es.js
@@ -24130,7 +24130,7 @@ var waitAndReturnEvents = function (eth, txHash, abi) {
 // todo replace with a better polling
 var waitForTransaction = function (eth, txHash) {
     return new Promise(function (resolve, reject) {
-        var secMax = 30;
+        var secMax = 60;
         var sec = 0;
         var wait = function (txHash) {
             setTimeout(function () {

--- a/dist/Tinlake.es.js
+++ b/dist/Tinlake.es.js
@@ -24029,6 +24029,17 @@ var Tinlake = /** @class */ (function () {
                 return waitAndReturnEvents(_this.eth, txHash, _this.contracts['nft'].abi);
             });
         };
+        this.getAppraisal = function (loanID) { return __awaiter(_this, void 0, void 0, function () {
+            var res;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.contracts.appraiser.value(loanID)];
+                    case 1:
+                        res = _a.sent();
+                        return [2 /*return*/, res['0']];
+                }
+            });
+        }); };
         /**
          * @param to Address that should receive the currency (e. g. DAI)
          */

--- a/dist/Tinlake.js
+++ b/dist/Tinlake.js
@@ -24134,7 +24134,7 @@ var waitAndReturnEvents = function (eth, txHash, abi) {
 // todo replace with a better polling
 var waitForTransaction = function (eth, txHash) {
     return new Promise(function (resolve, reject) {
-        var secMax = 5;
+        var secMax = 30;
         var sec = 0;
         var wait = function (txHash) {
             setTimeout(function () {
@@ -24149,8 +24149,11 @@ var waitForTransaction = function (eth, txHash) {
                     }
                     console.log("waiting for tx :" + txHash);
                     sec = sec + 1;
-                    if (sec !== secMax) {
+                    if (sec < secMax) {
                         wait(txHash);
+                    }
+                    else {
+                        reject("waiting for transaction tx " + tx + " timed out after " + secMax + " seconds");
                     }
                 });
             }, 1000);

--- a/dist/Tinlake.js
+++ b/dist/Tinlake.js
@@ -24134,7 +24134,7 @@ var waitAndReturnEvents = function (eth, txHash, abi) {
 // todo replace with a better polling
 var waitForTransaction = function (eth, txHash) {
     return new Promise(function (resolve, reject) {
-        var secMax = 30;
+        var secMax = 60;
         var sec = 0;
         var wait = function (txHash) {
             setTimeout(function () {

--- a/dist/Tinlake.js
+++ b/dist/Tinlake.js
@@ -24033,6 +24033,17 @@ var Tinlake = /** @class */ (function () {
                 return waitAndReturnEvents(_this.eth, txHash, _this.contracts['nft'].abi);
             });
         };
+        this.getAppraisal = function (loanID) { return __awaiter(_this, void 0, void 0, function () {
+            var res;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.contracts.appraiser.value(loanID)];
+                    case 1:
+                        res = _a.sent();
+                        return [2 /*return*/, res['0']];
+                }
+            });
+        }); };
         /**
          * @param to Address that should receive the currency (e. g. DAI)
          */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinlake",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinlake",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinlake",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "typescript": "^3.5.2"
   },
   "scripts": {
-    "bundle": "rollup -c",
+    "build": "rollup -c",
     "watch": "rollup -cw",
-    "test": "npm run bundle && ts-mocha -p test/tsconfig.json test/**/*",
-    "nodemon": "nodemon node inspect src/index.js"
+    "test": "npm run build && ts-mocha -p test/tsconfig.json test/**/*",
+    "nodemon": "nodemon node inspect dist/Tinlake.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinlake",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Centrifuge Tinlake Contracts Client",
   "main": "dist/Tinlake.js",
   "types": "dist/Tinlake.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinlake",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Centrifuge Tinlake Contracts Client",
   "main": "dist/Tinlake.js",
   "types": "dist/Tinlake.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinlake",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Centrifuge Tinlake Contracts Client",
   "main": "dist/Tinlake.js",
   "types": "dist/Tinlake.d.ts",

--- a/src/Tinlake.ts
+++ b/src/Tinlake.ts
@@ -220,6 +220,11 @@ class Tinlake {
       });
   }
 
+  getAppraisal = async (loanID: string): Promise<BN> => {
+    const res = await this.contracts.appraiser.value(loanID);
+    return res['0'];
+  }
+
   /**
    * @param to Address that should receive the currency (e. g. DAI)
    */

--- a/src/Tinlake.ts
+++ b/src/Tinlake.ts
@@ -280,7 +280,7 @@ const waitAndReturnEvents = (eth: ethI, txHash: string, abi: any) => {
 // todo replace with a better polling
 const waitForTransaction = (eth: ethI, txHash: any) => {
   return new Promise((resolve, reject) => {
-    const secMax = 30;
+    const secMax = 60;
     let sec = 0;
     const wait = (txHash: string) => {
       setTimeout(() => {

--- a/src/Tinlake.ts
+++ b/src/Tinlake.ts
@@ -280,7 +280,7 @@ const waitAndReturnEvents = (eth: ethI, txHash: string, abi: any) => {
 // todo replace with a better polling
 const waitForTransaction = (eth: ethI, txHash: any) => {
   return new Promise((resolve, reject) => {
-    const secMax = 5;
+    const secMax = 30;
     let sec = 0;
     const wait = (txHash: string) => {
       setTimeout(() => {
@@ -295,10 +295,11 @@ const waitForTransaction = (eth: ethI, txHash: any) => {
           }
           console.log(`waiting for tx :${txHash}`);
           sec = sec + 1;
-          if (sec !== secMax) {
+          if (sec < secMax) {
             wait(txHash);
+          } else {
+            reject(`waiting for transaction tx ${tx} timed out after ${secMax} seconds`);
           }
-
         });
       },         1000);
 

--- a/src/abi/Appraiser.abi.json
+++ b/src/abi/Appraiser.abi.json
@@ -1,1 +1,119 @@
-[{"constant":false,"inputs":[{"name":"usr","type":"address"}],"name":"rely","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"loan","type":"uint256"},{"name":"wad","type":"uint256"}],"name":"file","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"usr","type":"address"}],"name":"deny","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"wards","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"uint256"}],"name":"value","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"loan","type":"uint256"},{"name":"registry","type":"address"},{"name":"tokenId","type":"uint256"}],"name":"appraise","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"inputs":[],"payable":false,"stateMutability":"nonpayable","type":"constructor"}]
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "usr",
+        "type": "address"
+      }
+    ],
+    "name": "rely",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "loan",
+        "type": "uint256"
+      },
+      {
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "file",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "usr",
+        "type": "address"
+      }
+    ],
+    "name": "deny",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "wards",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "value",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "loan",
+        "type": "uint256"
+      },
+      {
+        "name": "registry",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "appraise",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  }
+]

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -20,6 +20,8 @@ const tokenID = `0x${Math.floor(Math.random() * (10 ** 15))}`;
 let loanID: string;
 
 const gasLimit = 1000000;
+const principal = '100';
+const appraisal = '300';
 
 describe('functional tinlake tests', () => {
   before(() => {
@@ -49,8 +51,6 @@ describe('functional tinlake tests', () => {
 
   describe('tinlake borrow and repay', function () {
     this.timeout(50000);
-    const principal = '100';
-    const appraisal = '300';
     it('borrow and repay successful', () => {
       console.log(`appraisal: ${appraisal}`);
       console.log(`principal: ${principal}`);
@@ -160,6 +160,11 @@ describe('functional tinlake tests', () => {
     it('gets the owner of an nft', async () => {
       const res = await adminTinlake.ownerOfNFT(tokenID);
       assert.equal(typeof res, 'string');
+    });
+
+    it('gets the appraisal of a loan', async () => {
+      const res = await adminTinlake.getAppraisal(loanID);
+      assert.equal(res.toString(), appraisal);
     });
   });
 });


### PR DESCRIPTION
There was a max waiting time for transaction results of 5 secs set – was that intended? I regularly had failing transactions because of that and increased the max time to 30 seconds. 

This PR also rejects a pending transaction if the timeout is reached.
